### PR TITLE
Fix defer message data

### DIFF
--- a/Rebus.Idempotency.MySql.Tests/TestIdempotentMessageStorage.cs
+++ b/Rebus.Idempotency.MySql.Tests/TestIdempotentMessageStorage.cs
@@ -58,7 +58,7 @@ namespace Rebus.Idempotency.MySql.Tests
             idempotencyData.MarkMessageAsHandled(Guid.NewGuid().ToString());
             idempotencyData.AddOutgoingMessage(
                 Guid.NewGuid().ToString(), 
-                new []{ "test_destination"}, 
+                new []{ "test_destination" }, 
                 new TransportMessage(new Dictionary<string, string>(), Encoding.ASCII.GetBytes("test_body")));
 
             var msgData = new MessageData

--- a/Rebus.Idempotency.MySql/MySqlMessageStorage.cs
+++ b/Rebus.Idempotency.MySql/MySqlMessageStorage.cs
@@ -50,7 +50,7 @@ namespace Rebus.Idempotency.MySql
                         {
                             if (!await reader.ReadAsync()) return null;
 
-                            var msgId = ((Guid) reader.ExtractValue("message_id")).ToString();
+                            var msgId = (string) reader.ExtractValue("message_id");
                             var inputQueueAddress = (string) reader.ExtractValue("input_queue_address");
                             var processingThreadId = (int?) reader.ExtractValue("processing_thread_id");
                             var timeThreadIdAssigned = (DateTime?) reader.ExtractValue("time_thread_id_assigned");

--- a/Rebus.Idempotency/IdempotentMessageIncomingStep.cs
+++ b/Rebus.Idempotency/IdempotentMessageIncomingStep.cs
@@ -35,7 +35,7 @@ namespace Rebus.Idempotency
         public async Task Process(IncomingStepContext context, Func<Task> next)
         {
             var message = context.Load<Message>();
-            var messageId = GetMessageId(message);
+            var messageId = message.GetMessageIdWithDeferCount();
 
             var transactionContext = context.Load<ITransactionContext>();
 
@@ -107,16 +107,6 @@ namespace Rebus.Idempotency
             {
                 // The LoadMessageDataStep was not triggered 
                 await next();
-            }
-
-            string GetMessageId(Message msg)
-            {
-                var deferCount = message.Headers.TryGetValue(Headers.DeferCount, out var result)
-                    ? int.Parse(result)
-                    : 0;
-
-                // if the message got defered, it needs a new ID in terms of idempotency.
-                return msg.GetMessageId() + (deferCount > 0 ? $"-{deferCount}" : "");
             }
         }
     }

--- a/Rebus.Idempotency/IdempotentMessageOutgoingStep.cs
+++ b/Rebus.Idempotency/IdempotentMessageOutgoingStep.cs
@@ -29,8 +29,7 @@ namespace Rebus.Idempotency
         {
             var transactionContext = context.Load<ITransactionContext>();
 
-            object temp;
-            if (transactionContext.Items.TryGetValue(Keys.MessageData, out temp))
+            if (transactionContext.Items.TryGetValue(Keys.MessageData, out object temp))
             {
                 var msgData = (MessageData)temp;
 
@@ -39,7 +38,7 @@ namespace Rebus.Idempotency
                     var transportMessage = context.Load<TransportMessage>();
                     var destinationAddresses = context.Load<DestinationAddresses>();
                     var incomingStepContext = transactionContext.Items.GetOrThrow<IncomingStepContext>(StepContext.StepContextKey);
-                    var messageId = incomingStepContext.Load<Message>().GetMessageId();
+                    var messageId = incomingStepContext.Load<Message>().GetMessageIdWithDeferCount();
 
                     _log.Info($"Adding outgoing message with ID {transportMessage.Headers[Headers.MessageId]} for message with ID {msgData.MessageId} onto the message data.");
                     msgData.AddOutgoingMessage(messageId, destinationAddresses, transportMessage);

--- a/Rebus.Idempotency/LoadMessageDataStep.cs
+++ b/Rebus.Idempotency/LoadMessageDataStep.cs
@@ -28,7 +28,7 @@ namespace Rebus.Idempotency
         public async Task Process(IncomingStepContext context, Func<Task> next)
         {
             var message = context.Load<Message>();
-            var messageId = message.GetMessageId();
+            var messageId = message.GetMessageIdWithDeferCount();
 
             var transactionContext = context.Load<ITransactionContext>();
             var messageData = await _msgStorage.Find(messageId) ?? new MessageData() { MessageId = messageId };

--- a/Rebus.Idempotency/MessageExtensions.cs
+++ b/Rebus.Idempotency/MessageExtensions.cs
@@ -1,0 +1,28 @@
+using Rebus.Bus;
+using Rebus.Messages;
+
+namespace Rebus.Idempotency
+{
+    public static class MessageExtensions
+    {
+        public static string GetMessageIdWithDeferCount(this Message message)
+        {
+            var deferCount = message.Headers.TryGetValue(Headers.DeferCount, out var result)
+                ? int.Parse(result)
+                : 0;
+
+            // if the message got defered, it needs a new ID in terms of idempotency.
+            return message.GetMessageId() + (deferCount > 0 ? $"-{deferCount}" : "");
+        }
+
+        public static string GetMessageIdWithDeferCount(this TransportMessage message)
+        {
+            var deferCount = message.Headers.TryGetValue(Headers.DeferCount, out var result)
+                ? int.Parse(result)
+                : 0;
+
+            // if the message got defered, it needs a new ID in terms of idempotency.
+            return message.GetMessageId() + (deferCount > 0 ? $"-{deferCount}" : "");
+        }
+    }
+}

--- a/Rebus.Idempotency/OutgoingMessages.cs
+++ b/Rebus.Idempotency/OutgoingMessages.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace Rebus.Idempotency
 {
@@ -39,6 +37,9 @@ namespace Rebus.Idempotency
         /// </summary>
         public void Add(OutgoingMessage outgoingMessage)
         {
+            // A message should not send itself, as it might end up in an infinite loop
+            if(outgoingMessage.TransportMessage.GetMessageIdWithDeferCount() == MessageId) return;
+
             _messagesToSend.Add(outgoingMessage);
         }
     }

--- a/Rebus.Idempotency/Rebus.Idempotency.csproj
+++ b/Rebus.Idempotency/Rebus.Idempotency.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Rebus.Idempotency/Rebus.Idempotency.csproj
+++ b/Rebus.Idempotency/Rebus.Idempotency.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.0.1</VersionPrefix>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
The messageId should always include the defercount, so that outgoing messages from the previous messages don't send out indefinitely. Now, every deferred messaged will have a separate id in the idempotency table.