### PR TITLE
Maintenance/update rebus mysql version

### DIFF
--- a/ConsoleApp1/ConsoleApp1.csproj
+++ b/ConsoleApp1/ConsoleApp1.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Rebus.Idempotency.MySql.Tests/Rebus.Idempotency.MySql.Tests.csproj
+++ b/Rebus.Idempotency.MySql.Tests/Rebus.Idempotency.MySql.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/Rebus.Idempotency.MySql/MySqlMessageStorage.cs
+++ b/Rebus.Idempotency.MySql/MySqlMessageStorage.cs
@@ -1,11 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Data.SqlClient;
 using System.Threading.Tasks;
-using Rebus.Extensions;
 using Rebus.Logging;
 using Rebus.Idempotency.MySql.Extensions;
-using System.Collections.Generic;
 
 namespace Rebus.Idempotency.MySql
 {
@@ -186,7 +185,7 @@ namespace Rebus.Idempotency.MySql
                         }
                     }
 
-                    if(!columns.Exists(x => x.columnName == "defer_count" && x.dataType == "tinyint")) 
+                    if(!columns.Exists(x => x.columnName == "defer_count" && x.dataType == "tinyint"))
                     {
                         throw new Exception("The defer_count column is required to be tinyint for this package version. " +
                             $"Please update the database schema for your idempotency table: {_dataTableName}.");
@@ -199,7 +198,7 @@ namespace Rebus.Idempotency.MySql
         {
             using (var connection = await _connectionHelper.GetConnection())
             {
-                var tableNames = connection.GetTableNames().ToHashSet();
+                var tableNames = new HashSet<string>(connection.GetTableNames());
 
                 var hasDataTable = tableNames.Contains(_dataTableName);
 

--- a/Rebus.Idempotency.MySql/Rebus.Idempotency.MySql.csproj
+++ b/Rebus.Idempotency.MySql/Rebus.Idempotency.MySql.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -28,7 +28,7 @@
     <DefineConstants>NETSTANDARD1_6</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Rebus.MySql" Version="2.1.*" />
+    <PackageReference Include="Rebus.MySql" Version="2.2.*" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Rebus.Idempotency\Rebus.Idempotency.csproj" />

--- a/Rebus.Idempotency.Tests/Rebus.Idempotency.Tests.csproj
+++ b/Rebus.Idempotency.Tests/Rebus.Idempotency.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Application of [this Rebus PR](https://github.com/rebus-org/Rebus.MySql/pull/28)

I've deployed a [v2.1.0-beta001](https://dev.azure.com/GantnerNv/Enviso/_artifacts/feed/enviso-dotnet/NuGet/Rebus.Idempotency.MySql/versions/2.1.0-beta001) package to test in our services.